### PR TITLE
test(build): add gcc test to quality workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,13 @@ add_custom_target(quality-gcc-build
   COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR} ${CMAKE_COMMAND} --build --preset debug-gcc
   COMMENT "Configuring and building GCC debug preset")
 
+# Runs a GCC debug build and tests from the source root so quality can include GCC compilation and tests.
+add_custom_target(quality-gcc-test
+  COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR} ${CMAKE_COMMAND} --preset debug-gcc
+  COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR} ${CMAKE_COMMAND} --build --preset debug-gcc
+  COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR} ${CMAKE_COMMAND} --build --target test --preset debug-gcc
+  COMMENT "Configuring, building, and testing GCC debug preset")
+
 include(CTest)
 
 set(PROJECT_ROOT ${CMAKE_SOURCE_DIR})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -91,6 +91,13 @@
   ],
 
   "buildPresets": [
+        {
+          "name": "quality-gcc-test",
+          "displayName": "Run GCC build and test from quality",
+          "inherits": "base-build",
+          "configurePreset": "debug-clang",
+          "targets": ["quality-gcc-test"]
+        },
     {
       "name": "base-build",
       "hidden": true,
@@ -318,10 +325,10 @@
         { "type": "configure", "name": "debug-clang" },
         { "type": "build",     "name": "format-check" },
         { "type": "build",     "name": "debug-clang" },
-        { "type": "build",     "name": "quality-gcc-build" },
+        { "type": "build",     "name": "quality-gcc-test" },
         { "type": "build",     "name": "clang-tidy" },
-        { "type": "test",      "name": "debug_ctest-clang" }
-        ,{ "type": "build",     "name": "doxygen" }
+        { "type": "test",      "name": "debug_ctest-clang" },
+        { "type": "build",     "name": "doxygen" }
       ]
     },
     {


### PR DESCRIPTION
The quality-gcc-test build preset uses the debug-clang configure preset because CMake requires every build preset to reference a configure preset, and the workflow itself is configured with Clang. However, the custom target quality-gcc-test actually runs its own CMake commands with the --preset debug-gcc option, which configures and builds the project using GCC, regardless of the parent workflow's toolchain.

So, the debug-clang configure preset is only used to satisfy CMake's requirements for the build preset, but the real GCC build and test are performed by the commands inside the custom target. This is a workaround to allow running a GCC build/test from a Clang-based workflow.