### PR TITLE
fix(fileinput): fix -D argument

### DIFF
--- a/inc/parseargs.h
+++ b/inc/parseargs.h
@@ -59,10 +59,11 @@ double getDouble(char* ptr);
  */
 int getDoublesFromStdin(size_t maxCount, double* arr);
 
-/** @brief Reads integers from standard input until EOF or maxCount is reached.
+/** @brief Reads integers from file until EOF or maxCount is reached.
  *
  * @param maxCount The maximum number of integers to read.
  * @param arr Pointer to an array where the read integers will be stored.
+ * @param file Pointer to read integers from
  * @return The number of integers successfully read.
  */
-int getIntsFromStdin(size_t maxCount, int* arr);
+int getIntsFromFile(size_t maxCount, int* arr, FILE* file);

--- a/src/capture_helpers.c
+++ b/src/capture_helpers.c
@@ -67,7 +67,7 @@ void fillReference(FILE* fpDefPeak, struct myarr* reference, size_t teeth)
         {
             for (size_t j = 0; j < reference->ArrayLength; j++)
             {
-                int int_count = getIntsFromStdin(4, arr);
+                int int_count = getIntsFromFile(4, arr, fpDefPeak);
                 if (int_count < 0)
                 {
                     break;

--- a/src/parseargs.c
+++ b/src/parseargs.c
@@ -330,7 +330,7 @@ int getDoublesFromStdin(size_t maxCount, double* arr)
     return (int)parsed; // returns 0..maxCount
 }
 
-int getIntsFromStdin(size_t maxCount, int* arr)
+int getIntsFromFile(size_t maxCount, int* arr, FILE* file)
 {
     if (!arr || maxCount == 0)
     {
@@ -339,7 +339,7 @@ int getIntsFromStdin(size_t maxCount, int* arr)
 
     char* line = NULL;
     size_t len = 0;
-    ssize_t nread = getline(&line, &len, stdin);
+    ssize_t nread = getline(&line, &len, file);
     if (nread == -1)
     {
         free(line);


### PR DESCRIPTION
the def peak should be read from the file, not the stdin

## Linked issue (required)
<!-- Use a closing keyword so it shows up in Development -->
Fixes #33

## What changed
- Made a new method to read from file not stdin

## Why
- input stream was wrong

## How to test
- try -D option

